### PR TITLE
Migrate from deprecated gradle action to a new one

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,9 +23,9 @@ jobs:
           distribution: 'zulu'
           java-version: 21
 
-      - uses: gradle/gradle-build-action@v3
-        with:
-          arguments: build --scan --full-stacktrace
+      - uses: gradle/actions/setup-gradle@v3
+
+      - run: ./gradlew build --scan --full-stacktrace
 
       - name: Bundle the build report
         if: failure()

--- a/.github/workflows/githubpages.yaml
+++ b/.github/workflows/githubpages.yaml
@@ -16,9 +16,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: gradle/gradle-build-action@v3
-        with:
-          arguments: -Pversion=${{ github.event.release.tag_name }} dokkaHtml
+      - uses: gradle/actions/setup-gradle@v3
+
+      - run: ./gradlew -Pversion=${{ github.event.release.tag_name }} dokkaHtml
 
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,9 +21,9 @@ jobs:
           distribution: 'zulu'
           java-version: 21
 
-      - uses: gradle/gradle-build-action@v3
-        with:
-          arguments: build --scan --full-stacktrace
+      - uses: gradle/actions/setup-gradle@v3
+
+      - run: ./gradlew build --scan --full-stacktrace
 
       - name: Bundle the build report
         if: failure()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,9 +30,9 @@ jobs:
           distribution: 'zulu'
           java-version: 11
 
-      - uses: gradle/gradle-build-action@v3
-        with:
-          arguments: assemble -Pversion=${{ inputs.version }}
+      - uses: gradle/actions/setup-gradle@v3
+
+      - run: ./gradlew assemble -Pversion=${{ inputs.version }}
 
       - name: Upload reports
         if: failure()


### PR DESCRIPTION
It is recommended to migrate from `gradle/gradle-build-action` to `gradle/actions/setup-gradle` action - more information [here](https://github.com/gradle/gradle-build-action).