### PR TITLE
Add Kaml for YAML support and update serialization logic

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,7 +18,7 @@ jobs:
       
       - name: Enable auto-merge for Dependabot PRs
         if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ ktor-client = { module= "io.ktor:ktor-client-core", version.ref="ktor" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref="kotlinpoet" }
 android-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 test-compile = { module = "dev.zacsweers.kctfork:core", version.ref = "test-compile"}
+kaml = { group = "com.charleskorn.kaml", name = "kaml", version = "0.83.0" }
 
 [plugins]
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }

--- a/parser/build.gradle.kts
+++ b/parser/build.gradle.kts
@@ -10,18 +10,17 @@ plugins {
 
 kotlin {
   explicitApi()
+  jvmToolchain(11)
 
   jvm()
-  //  macosArm64()
-  //  linuxX64()
+  macosArm64()
+  linuxX64()
 
   sourceSets {
     commonMain {
       dependencies {
         api(libs.json)
-        // This should be KAML, but parsing OpenAI takes 57seconds
-        // Compared to 100ms with SnakeYAML
-        implementation("org.yaml:snakeyaml:2.3")
+        api(libs.kaml)
       }
     }
     jvmTest { dependencies { implementation(libs.test) } }

--- a/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/AdditionalProperties.kt
+++ b/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/AdditionalProperties.kt
@@ -1,10 +1,17 @@
 package io.github.nomisrev.openapi
 
+import com.charleskorn.kaml.YamlInput
+import com.charleskorn.kaml.YamlMap
+import com.charleskorn.kaml.YamlNode
+import com.charleskorn.kaml.YamlScalar
 import kotlin.jvm.JvmInline
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.SerialKind
+import kotlinx.serialization.descriptors.buildSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
@@ -23,22 +30,48 @@ public sealed interface AdditionalProperties {
 
   public companion object {
     internal object Serializer : KSerializer<AdditionalProperties> {
+      @OptIn(InternalSerializationApi::class, ExperimentalSerializationApi::class)
       override val descriptor =
-        buildClassSerialDescriptor("io.github.nomisrev.openapi.AdditionalProperties")
+        buildSerialDescriptor(
+          "io.github.nomisrev.openapi.AdditionalProperties",
+          SerialKind.CONTEXTUAL,
+        )
 
-      override fun deserialize(decoder: Decoder): AdditionalProperties {
-        decoder as JsonDecoder
-        val json = decoder.decodeSerializableValue(JsonElement.serializer())
-        return when {
-          json is JsonPrimitive && json.booleanOrNull != null -> Allowed(json.boolean)
-          json is JsonObject ->
-            PSchema(
-              decoder.json.decodeFromJsonElement(ReferenceOr.serializer(Schema.serializer()), json)
-            )
-          else ->
-            throw SerializationException("AdditionalProperties can only be a boolean or a schema")
+      override fun deserialize(decoder: Decoder): AdditionalProperties =
+        when {
+          decoder is JsonDecoder -> {
+            val json = decoder.decodeSerializableValue(JsonElement.serializer())
+            when {
+              json is JsonPrimitive && json.booleanOrNull != null -> Allowed(json.boolean)
+              json is JsonObject ->
+                PSchema(
+                  decoder.json.decodeFromJsonElement(
+                    ReferenceOr.serializer(Schema.serializer()),
+                    json,
+                  )
+                )
+
+              else ->
+                throw SerializationException(
+                  "AdditionalProperties can only be a boolean or a schema"
+                )
+            }
+          }
+          decoder is YamlInput -> {
+            val node = decoder.decodeSerializableValue(YamlNode.serializer())
+            when {
+              node is YamlScalar -> Allowed(node.content.toBooleanStrict())
+              node is YamlMap ->
+                PSchema(ReferenceOr.serializer(Schema.serializer()).deserialize(decoder))
+
+              else ->
+                throw SerializationException(
+                  "AdditionalProperties can only be a boolean or a schema"
+                )
+            }
+          }
+          else -> error("Unknown decoder ($decoder) cannot deserialise AdditionalProperties.")
         }
-      }
 
       override fun serialize(encoder: Encoder, value: AdditionalProperties) {
         when (value) {

--- a/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/Components.kt
+++ b/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/Components.kt
@@ -1,3 +1,5 @@
+@file:Suppress("OPT_IN_USAGE")
+
 package io.github.nomisrev.openapi
 
 import kotlinx.serialization.InternalSerializationApi

--- a/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/Encoding.kt
+++ b/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/Encoding.kt
@@ -1,6 +1,6 @@
 package io.github.nomisrev.openapi
 
-import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KeepGeneratedSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonArray
@@ -11,7 +11,7 @@ import kotlinx.serialization.json.JsonPrimitive
 
 /** A single encoding definition applied to a single schema property. */
 @Serializable(Encoding.Companion.Serializer::class)
-@OptIn(InternalSerializationApi::class)
+@OptIn(ExperimentalSerializationApi::class)
 @KeepGeneratedSerializer
 public data class Encoding(
   /**

--- a/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/Example.kt
+++ b/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/Example.kt
@@ -1,6 +1,6 @@
 package io.github.nomisrev.openapi
 
-import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KeepGeneratedSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonArray
@@ -10,7 +10,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 
 @Serializable(Example.Companion.Serializer::class)
-@OptIn(InternalSerializationApi::class)
+@OptIn(ExperimentalSerializationApi::class)
 @KeepGeneratedSerializer
 public data class Example(
   /** Short description for the example. */

--- a/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/KSerializerWithExtensions.kt
+++ b/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/KSerializerWithExtensions.kt
@@ -1,5 +1,10 @@
 package io.github.nomisrev.openapi
 
+import com.charleskorn.kaml.YamlInput
+import com.charleskorn.kaml.YamlNode
+import com.charleskorn.kaml.yamlMap
+import kotlin.collections.component1
+import kotlin.collections.component2
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
@@ -17,17 +22,41 @@ internal abstract class KSerializerWithExtensions<T>(
 ) : KSerializer<T> {
   override val descriptor: SerialDescriptor = serializer.descriptor
 
-  override fun deserialize(decoder: Decoder): T {
-    decoder as JsonDecoder
-    val jsObject = decoder.decodeSerializableValue(JsonElement.serializer())
-    val value =
-      decoder.json.decodeFromJsonElement(
-        serializer,
-        JsonObject(jsObject.jsonObject.filterNot { (key, _) -> key.startsWith("x-") }),
-      )
-    val extensions = jsObject.jsonObject.filter { (key, _) -> key.startsWith("x-") }
-    return withExtensions(value, extensions)
-  }
+  override fun deserialize(decoder: Decoder): T =
+    when {
+      decoder is JsonDecoder -> {
+        val jsObject = decoder.decodeSerializableValue(JsonElement.serializer())
+        val value =
+          decoder.json.decodeFromJsonElement(
+            serializer,
+            JsonObject(jsObject.jsonObject.filterNot { (key, _) -> key.startsWith("x-") }),
+          )
+        val extensions = jsObject.jsonObject.filter { (key, _) -> key.startsWith("x-") }
+        withExtensions(value, extensions)
+      }
+
+      decoder is YamlInput -> {
+        val node = decoder.decodeSerializableValue(YamlNode.serializer())
+        val map = node.yamlMap
+        val value = decoder.yaml.decodeFromYamlNode(serializer, map)
+        val extensions =
+          buildMap<String, JsonElement> {
+            map.entries.forEach { (key, value) ->
+              if (key.content.startsWith("x-")) {
+                // TODO
+                //  For OpenAI: Caused by: MissingTypeTagException at
+                // paths./assistants.get.x-oaiMeta on line 104, column 9: Value is missing a type
+                // tag (eg. !<type>)
+                //                        put(key.content,
+                // decoder.yaml.decodeFromYamlNode(JsonElement.serializer(), value))
+              }
+            }
+          }
+        withExtensions(value, extensions)
+      }
+
+      else -> error("Unknown decoder ($decoder) cannot deserialize ${this::class.simpleName}.")
+    }
 
   override fun serialize(encoder: Encoder, value: T) {
     encoder as JsonEncoder

--- a/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/KamlUtils.kt
+++ b/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/KamlUtils.kt
@@ -1,0 +1,7 @@
+package io.github.nomisrev.openapi
+
+import com.charleskorn.kaml.YamlMap
+import com.charleskorn.kaml.YamlNode
+
+internal fun YamlMap.getOrNull(key: String): YamlNode? =
+  entries.firstNotNullOfOrNull { (scalar, node) -> if (scalar.content == key) node else null }

--- a/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/MediaType.kt
+++ b/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/MediaType.kt
@@ -1,6 +1,6 @@
 package io.github.nomisrev.openapi
 
-import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KeepGeneratedSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonArray
@@ -11,7 +11,7 @@ import kotlinx.serialization.json.JsonPrimitive
 
 /** Each Media Type Object provides schema and examples for the media type identified by its key. */
 @Serializable(MediaType.Companion.Serializer::class)
-@OptIn(InternalSerializationApi::class)
+@OptIn(ExperimentalSerializationApi::class)
 @KeepGeneratedSerializer
 public data class MediaType(
   /** The schema defining the content of the request, response, or parameter. */

--- a/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/Operation.kt
+++ b/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/Operation.kt
@@ -1,12 +1,12 @@
 package io.github.nomisrev.openapi
 
-import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KeepGeneratedSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 
 @Serializable(Operation.Companion.Serializer::class)
-@OptIn(InternalSerializationApi::class)
+@OptIn(ExperimentalSerializationApi::class)
 @KeepGeneratedSerializer
 public data class Operation(
   /**


### PR DESCRIPTION
- Switch from SnakeYAML to Kaml for efficient YAML parsing
- Update serialization methods to support both JSON and YAML decoding
- Replace deprecated `InternalSerializationApi` with `ExperimentalSerializationApi`
- Refactor to handle YAML-specific nodes and attributes
- Restore support for `macosArm64` and `linuxX64` builds