### PR TITLE
Add test for parsing object examples in YAML schema (#137)

### DIFF
--- a/parser/src/jvmTest/kotlin/io/github/nomisrev/openapi/CompositeExampleYamlTest.kt
+++ b/parser/src/jvmTest/kotlin/io/github/nomisrev/openapi/CompositeExampleYamlTest.kt
@@ -1,0 +1,25 @@
+package io.github.nomisrev.openapi
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class CompositeExampleYamlTest {
+  @Test
+  fun `object example under schema is parsed as string`() {
+    val openAPI = OpenAPI.fromYaml(resourceText("issue-composite-example.yaml"))
+
+    val path = openAPI.paths["/hello-world"] ?: fail("Path '/hello-world' not found")
+    val put = path.put ?: fail("PUT operation not found")
+    val requestBody = put.requestBody?.valueOrNull() ?: fail("RequestBody should be inline value")
+    val media =
+      requestBody.content["application/json"] ?: fail("MediaType 'application/json' not found")
+    val schema = media.schema?.valueOrNull() ?: fail("Schema should be inline value")
+
+    val example = schema.example ?: fail("Schema.example should not be null")
+    when (example) {
+      is ExampleValue.Single -> assertEquals("{\"name\":\"Foo\"}", example.value)
+      else -> fail("Expected ExampleValue.Single, but was $example")
+    }
+  }
+}

--- a/parser/src/jvmTest/resources/issue-composite-example.yaml
+++ b/parser/src/jvmTest/resources/issue-composite-example.yaml
@@ -1,0 +1,27 @@
+Composite examples are not handled:
+
+openapi: 3.0.1
+info:
+  title: Hello World API
+  description: A sample API to demonstrate authentication and connectivity
+  version: '1.0'
+paths:
+  /hello-world:
+    put:
+      operationId: hello-world
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+              example:
+                name: "Foo"
+      responses:
+        '200':
+          description: updated
+Output:
+
+  ExampleValue can only be a primitive or an array, found {"name":"Foo"}


### PR DESCRIPTION
- Introduce `CompositeExampleYamlTest` to verify parsing of composite examples.
- Add `issue-composite-example.yaml` to validate object example parsing.