### PR TITLE
Handle nullable enums in schemas and ensure consistent filtering of n…

### DIFF
--- a/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/Schema.kt
+++ b/parser/src/commonMain/kotlin/io/github/nomisrev/openapi/Schema.kt
@@ -67,7 +67,8 @@ public data class Schema(
   val maxItems: Int? = null,
   val minItems: Int? = null,
   val uniqueItems: Boolean? = null,
-  val enum: List<String>? = null,
+  // inner type nullable to allow explicit "null" value for nullable enums
+  val enum: List<String?>? = null,
   val multipleOf: Double? = null,
   @SerialName("\$id") val id: String? = null,
   @SerialName("\$anchor") val anchor: String? = null,

--- a/typed/src/commonMain/kotlin/io/github/nomisrev/openapi/OpenAPITransformer.kt
+++ b/typed/src/commonMain/kotlin/io/github/nomisrev/openapi/OpenAPITransformer.kt
@@ -141,7 +141,10 @@ private class OpenAPITransformer(private val openAPI: OpenAPI) {
         val model =
           when {
             schema.isOpenEnumeration() ->
-              schema.toOpenEnum(context, schema.anyOf!!.firstNotNullOf { it.resolve().value.enum }.filterNotNull())
+              schema.toOpenEnum(
+                context,
+                schema.anyOf!!.firstNotNullOf { it.resolve().value.enum }.filterNotNull(),
+              )
 
             /*
              * We're modifying the schema here...
@@ -651,7 +654,10 @@ private class OpenAPITransformer(private val openAPI: OpenAPI) {
           context is Named && case.value.type == Type.Basic.String && case.value.enum != null ->
             NamingContext.Nested(
               Named(
-                case.value.enum.orEmpty().filterNotNull().joinToString(prefix = "", separator = "Or") {
+                case.value.enum.orEmpty().filterNotNull().joinToString(
+                  prefix = "",
+                  separator = "Or",
+                ) {
                   it.replaceFirstChar(Char::uppercaseChar)
                 }
               ),

--- a/typed/src/commonMain/kotlin/io/github/nomisrev/openapi/OpenAPITransformer.kt
+++ b/typed/src/commonMain/kotlin/io/github/nomisrev/openapi/OpenAPITransformer.kt
@@ -141,7 +141,7 @@ private class OpenAPITransformer(private val openAPI: OpenAPI) {
         val model =
           when {
             schema.isOpenEnumeration() ->
-              schema.toOpenEnum(context, schema.anyOf!!.firstNotNullOf { it.resolve().value.enum })
+              schema.toOpenEnum(context, schema.anyOf!!.firstNotNullOf { it.resolve().value.enum }.filterNotNull())
 
             /*
              * We're modifying the schema here...
@@ -168,7 +168,14 @@ private class OpenAPITransformer(private val openAPI: OpenAPI) {
             schema.oneOf != null && schema.properties != null -> schema.toObject(context)
             schema.oneOf != null -> schema.toUnion(context, schema.oneOf!!)
             schema.allOf != null -> allOf(schema, context)
-            schema.enum != null -> schema.toEnum(context, schema.enum.orEmpty())
+            schema.enum != null -> {
+              val enums = schema.enum!!
+              val hasNull = enums.any { it == null }
+              val filtered = enums.filterNotNull()
+              val effectiveSchema =
+                if (hasNull && schema.nullable != true) schema.copy(nullable = true) else schema
+              effectiveSchema.toEnum(context, filtered)
+            }
             else -> schema.type(context)
           }
         Resolved.Value(model)
@@ -644,7 +651,7 @@ private class OpenAPITransformer(private val openAPI: OpenAPI) {
           context is Named && case.value.type == Type.Basic.String && case.value.enum != null ->
             NamingContext.Nested(
               Named(
-                case.value.enum!!.joinToString(prefix = "", separator = "Or") {
+                case.value.enum.orEmpty().filterNotNull().joinToString(prefix = "", separator = "Or") {
                   it.replaceFirstChar(Char::uppercaseChar)
                 }
               ),


### PR DESCRIPTION
…ull values

- Allow nullable values in `enum` definitions to support explicit `null`.
- Update `OpenAPITransformer` to handle filtered non-null enums while preserving nullable schema.
- Adjust naming logic for enums to handle null values gracefully.