### PR TITLE
Refactor package structure for OpenAPI generation

### DIFF
--- a/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/APIs.kt
+++ b/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/APIs.kt
@@ -1,4 +1,4 @@
-package io.github.nomisrev.openapi
+package io.github.nomisrev.openapi.generation
 
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
@@ -13,10 +13,13 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeSpecHolder
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.withIndent
+import io.github.nomisrev.openapi.API
+import io.github.nomisrev.openapi.Model
+import io.github.nomisrev.openapi.NamingContext
 import io.github.nomisrev.openapi.NamingContext.Named
 import io.github.nomisrev.openapi.NamingContext.Nested
-import io.ktor.http.*
-import io.ktor.utils.io.core.*
+import io.github.nomisrev.openapi.Root
+import io.github.nomisrev.openapi.Route
 
 fun configure(defaults: Boolean) =
   ParameterSpec(

--- a/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/Default.kt
+++ b/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/Default.kt
@@ -1,6 +1,7 @@
-package io.github.nomisrev.openapi
+package io.github.nomisrev.openapi.generation
 
 import com.squareup.kotlinpoet.ParameterSpec
+import io.github.nomisrev.openapi.Model
 import io.github.nomisrev.openapi.Model.Collection
 
 context(OpenAPIContext)

--- a/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/Interceptors.kt
+++ b/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/Interceptors.kt
@@ -1,6 +1,8 @@
-package io.github.nomisrev.openapi
+package io.github.nomisrev.openapi.generation
 
 import com.squareup.kotlinpoet.TypeSpec
+import io.github.nomisrev.openapi.API
+import io.github.nomisrev.openapi.Model
 import io.ktor.http.*
 import io.ktor.http.HttpMethod.Companion.Delete
 import io.ktor.http.HttpMethod.Companion.Get
@@ -27,13 +29,13 @@ interface APIInterceptor {
         override fun OpenAPIContext.intercept(api: API): API = api
 
         override fun OpenAPIContext.modifyInterface(
-          api: API,
-          typeSpec: TypeSpec.Builder,
+            api: API,
+            typeSpec: TypeSpec.Builder,
         ): TypeSpec.Builder = typeSpec
 
         override fun OpenAPIContext.modifyImplementation(
-          api: API,
-          typeSpec: TypeSpec.Builder,
+            api: API,
+            typeSpec: TypeSpec.Builder,
         ): TypeSpec.Builder = typeSpec
       }
   }

--- a/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/KotlinPoetExt.kt
+++ b/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/KotlinPoetExt.kt
@@ -1,4 +1,4 @@
-package io.github.nomisrev.openapi
+package io.github.nomisrev.openapi.generation
 
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.BOOLEAN
@@ -18,6 +18,7 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.asTypeName
+import io.github.nomisrev.openapi.Model
 import io.github.nomisrev.openapi.Model.Collection
 import kotlinx.serialization.json.JsonElement
 

--- a/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/KotlinTypeUtils.kt
+++ b/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/KotlinTypeUtils.kt
@@ -1,4 +1,4 @@
-package io.github.nomisrev.openapi
+package io.github.nomisrev.openapi.generation
 
 private val classNameRegex = Regex("^[a-zA-Z_$][a-zA-Z\\d_$]*$")
 

--- a/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/Main.kt
+++ b/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/Main.kt
@@ -1,5 +1,8 @@
-package io.github.nomisrev.openapi
+package io.github.nomisrev.openapi.generation
 
+import io.github.nomisrev.openapi.OpenAPI
+import io.github.nomisrev.openapi.models
+import io.github.nomisrev.openapi.root
 import kotlin.io.path.Path
 import okio.FileSystem
 import okio.Path.Companion.toPath
@@ -17,9 +20,9 @@ fun generate(config: GenerationConfig, fileSystem: FileSystem = FileSystem.SYSTE
   val rawSpec = fileSystem.read(config.path.toPath()) { readUtf8() }
   val openAPI =
     when (val extension = config.path.substringAfterLast(".")) {
-      "json" -> OpenAPI.fromJson(rawSpec)
+      "json" -> OpenAPI.Companion.fromJson(rawSpec)
       "yaml",
-      "yml" -> OpenAPI.fromYaml(rawSpec)
+      "yml" -> OpenAPI.Companion.fromYaml(rawSpec)
       else -> throw IllegalArgumentException("Unsupported file extension: $extension")
     }
   with(OpenAPIContext(config)) {

--- a/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/Models.kt
+++ b/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/Models.kt
@@ -1,6 +1,6 @@
 @file:Suppress("UNUSED_VARIABLE")
 
-package io.github.nomisrev.openapi
+package io.github.nomisrev.openapi.generation
 
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
@@ -19,7 +19,10 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.buildCodeBlock
 import com.squareup.kotlinpoet.withIndent
+import io.github.nomisrev.openapi.Constraints
+import io.github.nomisrev.openapi.Model
 import io.github.nomisrev.openapi.Model.Collection
+import io.github.nomisrev.openapi.NamingContext
 import io.github.nomisrev.openapi.NamingContext.Named
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
@@ -597,8 +600,8 @@ private fun Model.Object.Property.intRequirement(constraint: Constraints.Number)
 
 context(OpenAPIContext)
 private fun Model.Object.Property.numberRequirement(
-  constraint: Constraints.Number,
-  transform: (Double) -> Number,
+    constraint: Constraints.Number,
+    transform: (Double) -> Number,
 ): Requirement? {
   val paramName = toParamName(Named(baseName))
   val minimum = transform(constraint.minimum)

--- a/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/Naming.kt
+++ b/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/Naming.kt
@@ -1,7 +1,12 @@
-package io.github.nomisrev.openapi
+package io.github.nomisrev.openapi.generation
 
 import com.squareup.kotlinpoet.ClassName
+import io.github.nomisrev.openapi.Model
 import io.github.nomisrev.openapi.Model.Collection
+import io.github.nomisrev.openapi.NamingContext
+import io.github.nomisrev.openapi.Route
+import io.github.nomisrev.openapi.pathSegments
+
 fun Naming(`package`: String): Naming = Nam(`package`)
 
 context(Naming)

--- a/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/OpenAIInterceptor.kt
+++ b/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/OpenAIInterceptor.kt
@@ -1,4 +1,4 @@
-package io.github.nomisrev.openapi
+package io.github.nomisrev.openapi.generation
 
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
@@ -11,11 +11,15 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.withIndent
+import io.github.nomisrev.openapi.API
+import io.github.nomisrev.openapi.Model
 import io.github.nomisrev.openapi.NamingContext.Named
+import io.github.nomisrev.openapi.Route
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlin.collections.get
 
 fun APIInterceptor.Companion.openAIStreaming(`package`: String): APIInterceptor =
   object : APIInterceptor {
@@ -66,21 +70,21 @@ fun APIInterceptor.Companion.openAIStreaming(`package`: String): APIInterceptor 
     }
 
     override fun OpenAPIContext.modifyInterface(
-      api: API,
-      typeSpec: TypeSpec.Builder,
+        api: API,
+        typeSpec: TypeSpec.Builder,
     ): TypeSpec.Builder = modify(api, typeSpec, implemented = false)
 
     override fun OpenAPIContext.modifyImplementation(
-      api: API,
-      typeSpec: TypeSpec.Builder,
+        api: API,
+        typeSpec: TypeSpec.Builder,
     ): TypeSpec.Builder = modify(api, typeSpec, implemented = true)
 
     public var createPredef = false
 
     fun OpenAPIContext.modify(
-      api: API,
-      typeSpec: TypeSpec.Builder,
-      implemented: Boolean,
+        api: API,
+        typeSpec: TypeSpec.Builder,
+        implemented: Boolean,
     ): TypeSpec.Builder {
       val functions =
         api.routes

--- a/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/OpenAPIContext.kt
+++ b/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/OpenAPIContext.kt
@@ -1,4 +1,4 @@
-package io.github.nomisrev.openapi
+package io.github.nomisrev.openapi.generation
 
 import com.squareup.kotlinpoet.FileSpec
 import java.util.concurrent.atomic.AtomicReference

--- a/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/Predef.kt
+++ b/generation/src/main/kotlin/io/github/nomisrev/openapi/generation/Predef.kt
@@ -1,4 +1,4 @@
-package io.github.nomisrev.openapi
+package io.github.nomisrev.openapi.generation
 
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec

--- a/generation/src/test/kotlin/io/github/nomisrev/openapi/TestSyntax.kt
+++ b/generation/src/test/kotlin/io/github/nomisrev/openapi/TestSyntax.kt
@@ -6,6 +6,11 @@ import com.squareup.kotlinpoet.FileSpec
 import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
+import io.github.nomisrev.openapi.generation.GenerationConfig
+import io.github.nomisrev.openapi.generation.OpenAPIContext
+import io.github.nomisrev.openapi.generation.predef
+import io.github.nomisrev.openapi.generation.toFileSpecOrNull
+import io.github.nomisrev.openapi.generation.toFileSpecs
 import kotlin.test.assertEquals
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 
@@ -21,38 +26,38 @@ fun String.containsSingle(text: String): Boolean {
 private fun FileSpec.asCode(): String = buildString { writeTo(this) }
 
 fun Model.compiles(): String =
-  OpenAPIContext(GenerationConfig("", "", "io.test", "TestApi", true)) {
-    val file = requireNotNull(toFileSpecOrNull()) { "No File was generated for ${this@compiles}" }
-    val code = file.asCode()
-    val source = SourceFile.kotlin("${file.name}.kt", file.asCode())
-    val result =
-      KotlinCompilation()
-        .apply {
-          val predef = SourceFile.kotlin("Predef.kt", predef().asCode())
-          sources = listOf(source, predef)
-          inheritClassPath = true
-          messageOutputStream = System.out
-        }
-        .compile()
-    assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK, "${result.messages}\n$code")
-    code
-  }
+    OpenAPIContext(GenerationConfig("", "", "io.test", "TestApi", true)) {
+        val file = requireNotNull(toFileSpecOrNull()) { "No File was generated for ${this@compiles}" }
+        val code = file.asCode()
+        val source = SourceFile.kotlin("${file.name}.kt", file.asCode())
+        val result =
+            KotlinCompilation()
+                .apply {
+                    val predef = SourceFile.kotlin("Predef.kt", predef().asCode())
+                    sources = listOf(source, predef)
+                    inheritClassPath = true
+                    messageOutputStream = System.out
+                }
+                .compile()
+        assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK, "${result.messages}\n$code")
+        code
+    }
 
 fun API.compiles(): JvmCompilationResult =
-  OpenAPIContext(GenerationConfig("", "", "io.test", "TestApi", true)) {
-    val filesAsSources =
-      Root("TestApi", emptyList(), listOf(this@compiles)).toFileSpecs().map {
-        SourceFile.kotlin("${it.name}.kt", it.asCode())
-      }
-    val result =
-      KotlinCompilation()
-        .apply {
-          val predef = SourceFile.kotlin("Predef.kt", predef().asCode())
-          sources = filesAsSources + predef
-          inheritClassPath = true
-          messageOutputStream = System.out
-        }
-        .compile()
-    assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK, result.messages)
-    result
-  }
+    OpenAPIContext(GenerationConfig("", "", "io.test", "TestApi", true)) {
+        val filesAsSources =
+            Root("TestApi", emptyList(), listOf(this@compiles)).toFileSpecs().map {
+                SourceFile.kotlin("${it.name}.kt", it.asCode())
+            }
+        val result =
+            KotlinCompilation()
+                .apply {
+                    val predef = SourceFile.kotlin("Predef.kt", predef().asCode())
+                    sources = filesAsSources + predef
+                    inheritClassPath = true
+                    messageOutputStream = System.out
+                }
+                .compile()
+        assertEquals(result.exitCode, KotlinCompilation.ExitCode.OK, result.messages)
+        result
+    }

--- a/plugin/src/main/java/io/github/nomisrev/openapi/plugin/GenerateClientAction.kt
+++ b/plugin/src/main/java/io/github/nomisrev/openapi/plugin/GenerateClientAction.kt
@@ -1,7 +1,7 @@
 package io.github.nomisrev.openapi.plugin
 
-import io.github.nomisrev.openapi.GenerationConfig
-import io.github.nomisrev.openapi.generate
+import io.github.nomisrev.openapi.generation.GenerationConfig
+import io.github.nomisrev.openapi.generation.generate
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property


### PR DESCRIPTION
- Move OpenAPI-related classes under `io.github.nomisrev.openapi.generation` package for better organization.
- Add missing imports and adjust indentation in modified files.
- Update references across the project to reflect the new package structure.