### PR TITLE
Auto detect simply schemas such as String and FreeFormJson or fallback to raw HttpResponse

### DIFF
--- a/parser/src/commonTest/kotlin/io/github/nomisrev/openapi/parser/SchemaTest.kt
+++ b/parser/src/commonTest/kotlin/io/github/nomisrev/openapi/parser/SchemaTest.kt
@@ -1,13 +1,9 @@
 package io.github.nomisrev.openapi.parser
 
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.booleanOrNull
-import kotlinx.serialization.json.doubleOrNull
-import kotlinx.serialization.json.jsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs

--- a/renderer/src/jvmMain/kotlin/io/github/nomisrev/openapi/ClientRendererOperations.kt
+++ b/renderer/src/jvmMain/kotlin/io/github/nomisrev/openapi/ClientRendererOperations.kt
@@ -149,7 +149,10 @@ private fun TypeSpec.Builder.addOperationInlineTypes(context: OperationTypeSpecC
 private fun TypeSpec.Builder.addOperationResponseType(context: OperationTypeSpecContext) {
     when (val strategy = context.route.returns.contentTypeStrategy()) {
         ContentTypeStrategy.SingleContentType -> {
-            if (!context.route.returns.isSingleUnitResponse() && !context.route.returns.isSingleDirectModelResponse()) {
+            if (!context.route.returns.isSingleUnitResponse() &&
+                !context.route.returns.isSingleDirectModelResponse() &&
+                !context.route.returns.isSingleDirectRawResponse()
+            ) {
                 addType(context.route.buildResponseTypeSpec(context.config, context.methodClassName, context.inlineModelScope))
             }
         }

--- a/renderer/src/jvmMain/kotlin/io/github/nomisrev/openapi/ClientRendererResponses.kt
+++ b/renderer/src/jvmMain/kotlin/io/github/nomisrev/openapi/ClientRendererResponses.kt
@@ -68,15 +68,14 @@ internal fun Route.buildMultiContentTypeResponseSpecs(
 
         for ([statusCode, returnType] in returns.responses.entries.sortedBy { it.key.value }) {
             if (!statusCode.isSuccessStatusCode()) continue
-            val model = returnType.types[contentType] ?: continue
+            val body = returnType.body(contentType) ?: continue
             val rendering = buildMultiContentTypeResponseCaseTypeSpec(
                 config = config,
                 responseClassName = responseClassName,
                 statusCode = statusCode,
                 contentType = contentType,
-                model = model,
+                body = body,
                 hasMultipleStatuses = hasMultipleStatuses,
-                hasMultipleContentTypes = true,
                 inlineModelScope = inlineModelScope,
             )
             rendering.inlineTypeSpec?.let(builder::addType)
@@ -88,7 +87,7 @@ internal fun Route.buildMultiContentTypeResponseSpecs(
 
     for ([statusCode, returnType] in returns.responses.entries.sortedBy { it.key.value }) {
         if (statusCode.isSuccessStatusCode()) {
-            if (returnType.types.isEmpty()) {
+            if (returnType.contentTypes().isEmpty()) {
                 specs += buildSharedNoContentCaseTypeSpec(
                     caseName = statusCode.toCaseName(),
                     superinterfaces = allResponseInterfaces,
@@ -113,7 +112,7 @@ internal fun Route.buildMultiContentTypeResponseSpecs(
                     caseName = statusCode.toCaseName(),
                     statusCode = statusCode,
                     contentType = errorStrategy.contentType,
-                    model = errorStrategy.model,
+                    body = errorStrategy.body,
                     hasMultipleStatuses = hasMultipleStatuses,
                     hasMultipleContentTypes = false,
                     inlineModelScope = inlineModelScope,
@@ -121,7 +120,7 @@ internal fun Route.buildMultiContentTypeResponseSpecs(
             }
 
             is ErrorCaseStrategy.MultipleContentTypes -> {
-                errorStrategy.variants.forEach { [contentType, model] ->
+                errorStrategy.variants.forEach { [contentType, body] ->
                     val caseName = "${contentTypeToIdentifier(contentType)}${statusCode.toCaseName()}"
                     specs += buildSharedResponseCaseTypeSpec(
                         config = config,
@@ -130,7 +129,7 @@ internal fun Route.buildMultiContentTypeResponseSpecs(
                         caseName = caseName,
                         statusCode = statusCode,
                         contentType = contentType,
-                        model = model,
+                        body = body,
                         hasMultipleStatuses = hasMultipleStatuses,
                         hasMultipleContentTypes = true,
                         inlineModelScope = inlineModelScope,
@@ -194,6 +193,24 @@ private data class SealedResponseDefaultRendering(
     val inlineTypeSpec: TypeSpec?,
 )
 
+private fun buildRawResponseCaseTypeSpec(
+    caseName: String,
+    responseClassName: ClassName,
+): TypeSpec = TypeSpec.classBuilder(caseName)
+    .addModifiers(KModifier.DATA)
+    .primaryConstructor(
+        FunSpec.constructorBuilder()
+            .addParameter("value", HttpResponseType)
+            .build()
+    )
+    .addProperty(
+        PropertySpec.builder("value", HttpResponseType)
+            .initializer("value")
+            .build()
+    )
+    .addSuperinterface(responseClassName)
+    .build()
+
 @Suppress("UnsafeCallOnNullableType")
 internal fun Route.invokeReturnType(
     config: RenderConfig,
@@ -203,6 +220,7 @@ internal fun Route.invokeReturnType(
 ): TypeName =
     when {
         returns.isSingleUnitResponse() -> com.squareup.kotlinpoet.UNIT
+        returns.isSingleDirectRawResponse() -> HttpResponseType
         returns.isSingleDirectModelResponse() ->
             inlineModelScope.remapResponseType(requireNotNull(returns.singlePreferredModelOrNull(contentType)), config)
 
@@ -214,14 +232,22 @@ internal fun Route.invokeReturnType(
 
 internal fun Route.Returns.isSingleUnitResponse(): Boolean {
     if (needsSealedInterface()) return false
-    val model = singlePreferredModelOrNull()
-    return model == null || model is Model.Primitive.Unit
+    return when (val body = singlePreferredBodyOrNull()) {
+        null -> true
+        is Route.ReturnBody.Typed -> body.model is Model.Primitive.Unit
+        is Route.ReturnBody.Raw -> false
+    }
 }
 
 internal fun Route.Returns.isSingleDirectModelResponse(): Boolean {
     if (needsSealedInterface()) return false
     val model = singlePreferredModelOrNull()
     return model != null && model !is Model.Primitive.Unit && !model.isRouteInlineModel()
+}
+
+internal fun Route.Returns.isSingleDirectRawResponse(): Boolean {
+    if (needsSealedInterface()) return false
+    return singlePreferredBodyOrNull() is Route.ReturnBody.Raw
 }
 
 private fun Route.buildSealedResponseTypeSpec(
@@ -274,8 +300,14 @@ private fun buildSealedResponseCaseTypeSpec(
     inlineModelScope: OperationInlineModelScope,
 ): SealedResponseCaseRendering {
     val caseName = statusCode.toCaseName()
-    val model = returnType.preferredModel()
-    return if (model == null || model is Model.Primitive.Unit) {
+    val body = returnType.preferredBody()
+    val model = (body as? Route.ReturnBody.Typed)?.model
+    return if (body is Route.ReturnBody.Raw) {
+        SealedResponseCaseRendering(
+            caseTypeSpec = buildRawResponseCaseTypeSpec(caseName, responseClassName),
+            inlineTypeSpec = null,
+        )
+    } else if (model == null || model is Model.Primitive.Unit) {
         val caseBuilder = TypeSpec.objectBuilder(caseName)
             .addModifiers(KModifier.DATA)
             .addSuperinterface(responseClassName)
@@ -284,7 +316,7 @@ private fun buildSealedResponseCaseTypeSpec(
             inlineTypeSpec = null,
         )
     } else {
-        val hasMultipleContentTypes = returnType.types.size > 1
+        val hasMultipleContentTypes = returnType.contentTypes().size > 1
         if (model.isRouteInlineModel() && !hasMultipleContentTypes) {
             val caseTypeSpec = buildInlineResponseCaseTypeSpec(
                 model = model,
@@ -404,7 +436,8 @@ private fun buildSealedResponseDefaultTypeSpec(
     defaultReturnType: Route.ReturnType,
     inlineModelScope: OperationInlineModelScope,
 ): SealedResponseDefaultRendering {
-    val model = defaultReturnType.preferredModel()
+    val body = defaultReturnType.preferredBody()
+    val model = (body as? Route.ReturnBody.Typed)?.model
     val bodyTypeName = defaultBodyTypeName(
         contentType = null,
         hasMultipleContentTypes = false,
@@ -439,7 +472,14 @@ private fun buildSealedResponseDefaultTypeSpec(
             .build()
     )
 
-    if (model != null && model !is Model.Primitive.Unit) {
+    if (body is Route.ReturnBody.Raw) {
+        constructorBuilder.addParameter("value", HttpResponseType)
+        props.add(
+            PropertySpec.builder("value", HttpResponseType)
+                .initializer("value")
+                .build()
+        )
+    } else if (model != null && model !is Model.Primitive.Unit) {
         val typeName = requireNotNull(valueType)
         constructorBuilder.addParameter("value", typeName)
         props.add(
@@ -463,12 +503,18 @@ private fun buildMultiContentTypeResponseCaseTypeSpec(
     responseClassName: ClassName,
     statusCode: HttpStatusCode,
     contentType: ContentType,
-    model: Model,
+    body: Route.ReturnBody,
     hasMultipleStatuses: Boolean,
-    hasMultipleContentTypes: Boolean,
     inlineModelScope: OperationInlineModelScope,
 ): SealedResponseCaseRendering {
     val caseName = statusCode.toCaseName()
+    if (body is Route.ReturnBody.Raw) {
+        return SealedResponseCaseRendering(
+            caseTypeSpec = buildRawResponseCaseTypeSpec(caseName, responseClassName),
+            inlineTypeSpec = null,
+        )
+    }
+    val model = (body as Route.ReturnBody.Typed).model
     val directInlineCase = if (model.isRouteInlineModel()) {
         buildInlineResponseCaseTypeSpec(
             model = model,
@@ -491,7 +537,7 @@ private fun buildMultiContentTypeResponseCaseTypeSpec(
         statusCode = statusCode,
         contentType = contentType,
         hasMultipleStatuses = hasMultipleStatuses,
-        hasMultipleContentTypes = hasMultipleContentTypes,
+        hasMultipleContentTypes = true,
     )
     val inlineTypeSpec = if (model.isRouteInlineModel()) {
         buildInlineResponseBodyTypeSpec(
@@ -535,7 +581,7 @@ private fun buildSharedResponseCaseTypeSpec(
     caseName: String,
     statusCode: HttpStatusCode,
     contentType: ContentType,
-    model: Model,
+    body: Route.ReturnBody,
     hasMultipleStatuses: Boolean,
     hasMultipleContentTypes: Boolean,
     inlineModelScope: OperationInlineModelScope,
@@ -543,6 +589,23 @@ private fun buildSharedResponseCaseTypeSpec(
     val firstSuperinterface = requireNotNull(superinterfaces.firstOrNull()) {
         "Shared response cases require at least one success interface"
     }
+    if (body is Route.ReturnBody.Raw) {
+        return TypeSpec.classBuilder(caseName)
+            .addModifiers(KModifier.DATA)
+            .primaryConstructor(
+                FunSpec.constructorBuilder()
+                    .addParameter("value", HttpResponseType)
+                    .build()
+            )
+            .addProperty(
+                PropertySpec.builder("value", HttpResponseType)
+                    .initializer("value")
+                    .build()
+            )
+            .apply { superinterfaces.forEach(::addSuperinterface) }
+            .build()
+    }
+    val model = (body as Route.ReturnBody.Typed).model
     val directInlineCase = if (model.isRouteInlineModel()) {
         buildInlineResponseCaseTypeSpec(
             model = model,
@@ -619,11 +682,12 @@ private fun buildMultiContentTypeDefaultTypeSpec(
     superinterfaces: List<TypeName>,
     inlineModelScope: OperationInlineModelScope,
 ): SealedResponseDefaultRendering {
-    val model = defaultReturnType.preferredModel()
+    val body = defaultReturnType.preferredBody()
+    val model = (body as? Route.ReturnBody.Typed)?.model
     val defaultClassName = methodClassName.nestedClass("Default")
     val bodyTypeName = defaultBodyTypeName(
         contentType = null,
-        hasMultipleContentTypes = defaultReturnType.types.size > 1,
+        hasMultipleContentTypes = defaultReturnType.contentTypes().size > 1,
     )
     val inlineTypeSpec = if (model != null && model.isRouteInlineModel()) {
         buildInlineResponseBodyTypeSpec(
@@ -657,7 +721,14 @@ private fun buildMultiContentTypeDefaultTypeSpec(
             .build()
     )
 
-    if (model != null && model !is Model.Primitive.Unit) {
+    if (body is Route.ReturnBody.Raw) {
+        constructorBuilder.addParameter("value", HttpResponseType)
+        props.add(
+            PropertySpec.builder("value", HttpResponseType)
+                .initializer("value")
+                .build()
+        )
+    } else if (model != null && model !is Model.Primitive.Unit) {
         val typeName = requireNotNull(valueType)
         constructorBuilder.addParameter("value", typeName)
         props.add(
@@ -675,8 +746,11 @@ private fun buildMultiContentTypeDefaultTypeSpec(
     )
 }
 
+internal fun Route.Returns.singlePreferredBodyOrNull(): Route.ReturnBody? =
+    (responses.values.firstOrNull() ?: default)?.preferredBody()
+
 internal fun Route.Returns.singlePreferredModelOrNull(): Model? =
-    (responses.values.firstOrNull() ?: default)?.preferredModel()
+    (singlePreferredBodyOrNull() as? Route.ReturnBody.Typed)?.model
 
 private fun Route.Returns.singlePreferredModelOrNull(contentType: ContentType?): Model? {
     if (contentType == null || contentTypeStrategy() !is ContentTypeStrategy.SeparateMethods) {
@@ -685,11 +759,6 @@ private fun Route.Returns.singlePreferredModelOrNull(contentType: ContentType?):
     return responses.entries
         .asSequence()
         .filter { it.key.isSuccessStatusCode() }
-        .mapNotNull { [_, returnType] ->
-            returnType.types.entries.firstOrNull { [candidate, _] ->
-                candidate.match(contentType) || contentType.match(candidate)
-            }?.value
-        }
-        .firstOrNull()
+        .firstNotNullOfOrNull { [_, returnType] -> (returnType.body(contentType) as? Route.ReturnBody.Typed)?.model }
         ?: singlePreferredModelOrNull()
 }

--- a/renderer/src/jvmMain/kotlin/io/github/nomisrev/openapi/ClientRendererResponses.kt
+++ b/renderer/src/jvmMain/kotlin/io/github/nomisrev/openapi/ClientRendererResponses.kt
@@ -1,4 +1,5 @@
 @file:Suppress("TooManyFunctions")
+
 package io.github.nomisrev.openapi
 
 import com.squareup.kotlinpoet.ClassName
@@ -52,11 +53,13 @@ internal fun Route.buildMultiContentTypeResponseSpecs(
     inlineModelScope: OperationInlineModelScope,
 ): List<TypeSpec> {
     val strategy = returns.contentTypeStrategy() as? ContentTypeStrategy.SeparateMethods ?: return emptyList()
-    val responseInterfaces = strategy.successContentTypes.fold(linkedMapOf<ContentType, ClassName>()) { acc, contentType ->
-        val simpleName = contentTypeResponseTypeName(contentType, acc.values.mapTo(mutableSetOf()) { it.simpleName })
-        acc[contentType] = methodClassName.nestedClass(simpleName)
-        acc
-    }
+    val responseInterfaces =
+        strategy.successContentTypes.fold(linkedMapOf<ContentType, ClassName>()) { acc, contentType ->
+            val simpleName =
+                contentTypeResponseTypeName(contentType, acc.values.mapTo(mutableSetOf()) { it.simpleName })
+            acc[contentType] = methodClassName.nestedClass(simpleName)
+            acc
+        }
     val hasMultipleStatuses = returns.responses.size + (if (returns.default != null) 1 else 0) > 1
     val allResponseInterfaces = responseInterfaces.values.toList()
     val specs = mutableListOf<TypeSpec>()
@@ -352,6 +355,7 @@ private fun buildSealedResponseCaseTypeSpec(
             inlineTypeSpec != null -> responseClassName.nestedClass(
                 bodyTypeName
             )
+
             else -> inlineModelScope.remapResponseType(model, config)
         }
         val caseBuilder = TypeSpec.classBuilder(caseName)
@@ -589,8 +593,8 @@ private fun buildSharedResponseCaseTypeSpec(
     val firstSuperinterface = requireNotNull(superinterfaces.firstOrNull()) {
         "Shared response cases require at least one success interface"
     }
-    if (body is Route.ReturnBody.Raw) {
-        return TypeSpec.classBuilder(caseName)
+    return if (body is Route.ReturnBody.Raw) {
+        TypeSpec.classBuilder(caseName)
             .addModifiers(KModifier.DATA)
             .primaryConstructor(
                 FunSpec.constructorBuilder()
@@ -604,64 +608,65 @@ private fun buildSharedResponseCaseTypeSpec(
             )
             .apply { superinterfaces.forEach(::addSuperinterface) }
             .build()
-    }
-    val model = (body as Route.ReturnBody.Typed).model
-    val directInlineCase = if (model.isRouteInlineModel()) {
-        buildInlineResponseCaseTypeSpec(
-            model = model,
-            config = config,
-            responseClassName = firstSuperinterface as ClassName,
-            caseName = caseName,
-            externalTypeNames = inlineModelScope.externalTypeNames(),
-        )
     } else {
-        null
-    }
-    if (directInlineCase != null) {
-        return directInlineCase.toBuilder().apply {
-            superinterfaces.drop(1).forEach(::addSuperinterface)
-        }.build()
-    }
-
-    val caseClassName = methodClassName.nestedClass(caseName)
-    val bodyTypeName = bodyTypeName(
-        statusCode = statusCode,
-        contentType = contentType,
-        hasMultipleStatuses = hasMultipleStatuses,
-        hasMultipleContentTypes = hasMultipleContentTypes,
-    )
-    val inlineTypeSpec = if (model.isRouteInlineModel()) {
-        buildInlineResponseBodyTypeSpec(
-            model = model,
-            config = config,
-            ownerClassName = caseClassName,
-            nameOverride = bodyTypeName,
-            externalTypeNames = inlineModelScope.externalTypeNames(),
-        )
-    } else {
-        null
-    }
-    val typeName = when {
-        inlineTypeSpec != null -> caseClassName.nestedClass(bodyTypeName)
-        else -> inlineModelScope.remapResponseType(model, config)
-    }
-    return TypeSpec.classBuilder(caseName)
-        .addModifiers(KModifier.DATA)
-        .primaryConstructor(
-            FunSpec.constructorBuilder()
-                .addParameter("value", typeName)
-                .build()
-        )
-        .addProperty(
-            PropertySpec.builder("value", typeName)
-                .initializer("value")
-                .build()
-        )
-        .apply {
-            superinterfaces.forEach(::addSuperinterface)
-            inlineTypeSpec?.let(::addType)
+        val model = (body as Route.ReturnBody.Typed).model
+        val directInlineCase = if (model.isRouteInlineModel()) {
+            buildInlineResponseCaseTypeSpec(
+                model = model,
+                config = config,
+                responseClassName = firstSuperinterface as ClassName,
+                caseName = caseName,
+                externalTypeNames = inlineModelScope.externalTypeNames(),
+            )
+        } else {
+            null
         }
-        .build()
+        if (directInlineCase != null) {
+            return directInlineCase.toBuilder().apply {
+                superinterfaces.drop(1).forEach(::addSuperinterface)
+            }.build()
+        }
+
+        val caseClassName = methodClassName.nestedClass(caseName)
+        val bodyTypeName = bodyTypeName(
+            statusCode = statusCode,
+            contentType = contentType,
+            hasMultipleStatuses = hasMultipleStatuses,
+            hasMultipleContentTypes = hasMultipleContentTypes,
+        )
+        val inlineTypeSpec = if (model.isRouteInlineModel()) {
+            buildInlineResponseBodyTypeSpec(
+                model = model,
+                config = config,
+                ownerClassName = caseClassName,
+                nameOverride = bodyTypeName,
+                externalTypeNames = inlineModelScope.externalTypeNames(),
+            )
+        } else {
+            null
+        }
+        val typeName = when {
+            inlineTypeSpec != null -> caseClassName.nestedClass(bodyTypeName)
+            else -> inlineModelScope.remapResponseType(model, config)
+        }
+        TypeSpec.classBuilder(caseName)
+            .addModifiers(KModifier.DATA)
+            .primaryConstructor(
+                FunSpec.constructorBuilder()
+                    .addParameter("value", typeName)
+                    .build()
+            )
+            .addProperty(
+                PropertySpec.builder("value", typeName)
+                    .initializer("value")
+                    .build()
+            )
+            .apply {
+                superinterfaces.forEach(::addSuperinterface)
+                inlineTypeSpec?.let(::addType)
+            }
+            .build()
+    }
 }
 
 private fun buildSharedNoContentCaseTypeSpec(

--- a/renderer/src/jvmMain/kotlin/io/github/nomisrev/openapi/ContentTypeStrategy.kt
+++ b/renderer/src/jvmMain/kotlin/io/github/nomisrev/openapi/ContentTypeStrategy.kt
@@ -19,11 +19,11 @@ internal sealed interface ErrorCaseStrategy {
 
     data class SingleContentType(
         val contentType: ContentType,
-        val model: Model,
+        val body: Route.ReturnBody,
     ) : ErrorCaseStrategy
 
     data class MultipleContentTypes(
-        val variants: List<Pair<ContentType, Model>>,
+        val variants: List<Pair<ContentType, Route.ReturnBody>>,
     ) : ErrorCaseStrategy
 }
 
@@ -92,7 +92,7 @@ internal fun Route.Returns.contentTypeStrategy(): ContentTypeStrategy {
     val successContentTypes = responses.entries
         .asSequence()
         .filter { it.key.isSuccessStatusCode() }
-        .flatMap { [_, returnType] -> returnType.types.keys.asSequence().map(ContentType::normalizedForComparison) }
+        .flatMap { [_, returnType] -> returnType.contentTypes().asSequence().map(ContentType::normalizedForComparison) }
         .distinct()
         .toList()
     return if (successContentTypes.size <= 1) {
@@ -102,30 +102,35 @@ internal fun Route.Returns.contentTypeStrategy(): ContentTypeStrategy {
     }
 }
 
-internal fun Route.ReturnType.preferredModel(): Model? {
-    if (types.isEmpty()) return null
+internal fun Route.ReturnType.contentTypes(): List<ContentType> =
+    (types.keys + rawContentTypes).toList()
+
+internal fun Route.ReturnType.preferredBody(): Route.ReturnBody? {
     val jsonEntry = types.entries.firstOrNull { ContentType.Application.Json.match(it.key) }
-    return jsonEntry?.value ?: types.values.first()
+    if (jsonEntry != null) return Route.ReturnBody.Typed(jsonEntry.value)
+    val typed = types.values.firstOrNull()
+    if (typed != null) return Route.ReturnBody.Typed(typed)
+    return rawContentTypes.firstOrNull()?.let { Route.ReturnBody.Raw }
 }
 
 internal fun classifyErrorStatus(
     statusCode: HttpStatusCode,
     returnType: Route.ReturnType,
 ): ErrorCaseStrategy {
-    if (statusCode.value in NO_CONTENT_STATUS_CODE || returnType.types.isEmpty()) {
+    if (statusCode.value in NO_CONTENT_STATUS_CODE || returnType.contentTypes().isEmpty()) {
         return ErrorCaseStrategy.NoContent
     }
 
-    val variants = returnType.types.entries
+    val variants = returnType.bodies()
         .asSequence()
-        .map { [contentType, model] -> contentType.normalizedForComparison() to model }
+        .map { [contentType, body] -> contentType.normalizedForComparison() to body }
         .distinctBy { it.first }
         .toList()
     return when (variants.size) {
         0 -> ErrorCaseStrategy.NoContent
         1 -> ErrorCaseStrategy.SingleContentType(
             contentType = variants.single().first,
-            model = variants.single().second,
+            body = variants.single().second,
         )
 
         else -> ErrorCaseStrategy.MultipleContentTypes(variants)

--- a/renderer/src/jvmMain/kotlin/io/github/nomisrev/openapi/ImplRenderer.kt
+++ b/renderer/src/jvmMain/kotlin/io/github/nomisrev/openapi/ImplRenderer.kt
@@ -469,9 +469,24 @@ private fun Route.buildDirectOperationBody(
     val code = CodeBlock.builder()
     val request = operationRequestInvocationContext(method, includeBody, selectedBody, contentType)
 
-    val model = returns.singlePreferredModelOrNull()
-    if (model == null || model is Model.Primitive.Unit) {
-        code.addRequestInvocation(
+    when (val body = returns.singlePreferredBodyOrNull()) {
+        is Route.ReturnBody.Raw -> {
+            code.addRequestInvocation(
+                route = this,
+                request = request,
+                style = OperationRequestInvocationStyle.ResponseBinding,
+                config = config,
+                includeBody = includeBody,
+                selectedBody = selectedBody,
+                bodyExpr = bodyExpr,
+                bodyGuard = bodyGuard,
+                acceptContentType = contentType,
+                requestTypeContentType = requestTypeContentType,
+            )
+            code.addStatement("return response")
+        }
+
+        null -> code.addRequestInvocation(
             route = this,
             request = request,
             style = OperationRequestInvocationStyle.StatementOnly,
@@ -483,19 +498,34 @@ private fun Route.buildDirectOperationBody(
             acceptContentType = contentType,
             requestTypeContentType = requestTypeContentType,
         )
-    } else {
-        code.addRequestInvocation(
-            route = this,
-            request = request,
-            style = OperationRequestInvocationStyle.ReturnBody,
-            config = config,
-            includeBody = includeBody,
-            selectedBody = selectedBody,
-            bodyExpr = bodyExpr,
-            bodyGuard = bodyGuard,
-            acceptContentType = contentType,
-            requestTypeContentType = requestTypeContentType,
-        )
+
+        is Route.ReturnBody.Typed -> if (body.model is Model.Primitive.Unit) {
+            code.addRequestInvocation(
+                route = this,
+                request = request,
+                style = OperationRequestInvocationStyle.StatementOnly,
+                config = config,
+                includeBody = includeBody,
+                selectedBody = selectedBody,
+                bodyExpr = bodyExpr,
+                bodyGuard = bodyGuard,
+                acceptContentType = contentType,
+                requestTypeContentType = requestTypeContentType,
+            )
+        } else {
+            code.addRequestInvocation(
+                route = this,
+                request = request,
+                style = OperationRequestInvocationStyle.ReturnBody,
+                config = config,
+                includeBody = includeBody,
+                selectedBody = selectedBody,
+                bodyExpr = bodyExpr,
+                bodyGuard = bodyGuard,
+                acceptContentType = contentType,
+                requestTypeContentType = requestTypeContentType,
+            )
+        }
     }
 
     return code.build()
@@ -506,8 +536,8 @@ private fun Route.addSealedResponseStatusCases(code: CodeBlock.Builder, methodCl
     for ([statusCode, returnTypeEntry] in returns.responses.entries.sortedBy { it.key.value }) {
         val caseName = statusCode.toCaseName()
         val caseClassName = responseClassName.nestedClass(caseName)
-        val model = returnTypeEntry.preferredModel()
-        code.addStatement("%L -> %L", statusCode.value, buildResponseCaseExpression(caseClassName, model))
+        val body = returnTypeEntry.preferredBody()
+        code.addStatement("%L -> %L", statusCode.value, buildResponseCaseExpression(caseClassName, body))
     }
 }
 
@@ -515,11 +545,14 @@ private fun Route.addSealedResponseDefaultCase(code: CodeBlock.Builder, methodCl
     val responseClassName = methodClassName.nestedClass("Response")
     if (returns.default != null) {
         val defaultClassName = responseClassName.nestedClass("Default")
-        val defaultModel = returns.default!!.preferredModel()
-        if (defaultModel != null && defaultModel !is Model.Primitive.Unit) {
-            code.addStatement("else -> %T(response.status, response.%M())", defaultClassName, BodyMember)
-        } else {
-            code.addStatement("else -> %T(response.status)", defaultClassName)
+        when (val defaultBody = returns.default!!.preferredBody()) {
+            is Route.ReturnBody.Raw -> code.addStatement("else -> %T(response.status, response)", defaultClassName)
+            is Route.ReturnBody.Typed -> if (defaultBody.model is Model.Primitive.Unit) {
+                code.addStatement("else -> %T(response.status)", defaultClassName)
+            } else {
+                code.addStatement("else -> %T(response.status, response.%M())", defaultClassName, BodyMember)
+            }
+            null -> code.addStatement("else -> %T(response.status)", defaultClassName)
         }
     } else {
         code.addStatement(
@@ -538,14 +571,17 @@ private fun Route.addMultiContentTypeSealedResponseStatusCases(
     val responseClassName = methodClassName.nestedClass(contentTypeResponseTypeName(contentType))
     for ([statusCode, returnTypeEntry] in returns.responses.entries.sortedBy { it.key.value }) {
         if (statusCode.isSuccessStatusCode()) {
-            val model = returnTypeEntry.types[contentType] ?: continue
+            val body = returnTypeEntry.body(contentType) ?: continue
             val caseClassName = responseClassName.nestedClass(statusCode.toCaseName())
-            if (model is Model.Primitive.Unit) {
-                code.addStatement("%L -> %T", statusCode.value, caseClassName)
-            } else if (model.isRouteInlineModel() && model !is Model.Collection) {
-                code.addStatement("%L -> response.%M<%T>()", statusCode.value, BodyMember, caseClassName)
-            } else {
-                code.addStatement("%L -> %T(response.%M())", statusCode.value, caseClassName, BodyMember)
+            when (body) {
+                is Route.ReturnBody.Raw -> code.addStatement("%L -> %T(response)", statusCode.value, caseClassName)
+                is Route.ReturnBody.Typed -> if (body.model is Model.Primitive.Unit) {
+                    code.addStatement("%L -> %T", statusCode.value, caseClassName)
+                } else if (body.model.isRouteInlineModel() && body.model !is Model.Collection) {
+                    code.addStatement("%L -> response.%M<%T>()", statusCode.value, BodyMember, caseClassName)
+                } else {
+                    code.addStatement("%L -> %T(response.%M())", statusCode.value, caseClassName, BodyMember)
+                }
             }
             continue
         }
@@ -562,7 +598,7 @@ private fun Route.addMultiContentTypeSealedResponseStatusCases(
                 code.addStatement(
                     "%L -> %L",
                     statusCode.value,
-                    buildResponseCaseExpression(caseClassName, errorStrategy.model),
+                    buildResponseCaseExpression(caseClassName, errorStrategy.body),
                 )
             }
 
@@ -576,7 +612,7 @@ private fun Route.addMultiContentTypeSealedResponseStatusCases(
 private fun buildMultiCTErrorDispatch(
     methodClassName: ClassName,
     statusCode: HttpStatusCode,
-    variants: List<Pair<ContentType, Model>>,
+    variants: List<Pair<ContentType, Route.ReturnBody>>,
 ): CodeBlock {
     val preferredVariant = variants.firstOrNull { ContentType.Application.Json.match(it.first) } ?: variants.first()
     val code = CodeBlock.builder()
@@ -584,13 +620,13 @@ private fun buildMultiCTErrorDispatch(
     code.indent()
     code.addStatement("val ct = response.%M()", ContentTypeFunMember)
     code.beginControlFlow("when")
-    for ([errorContentType, errorModel] in variants) {
+    for ([errorContentType, errorBody] in variants) {
         val caseName = "${contentTypeToIdentifier(errorContentType)}${statusCode.toCaseName()}"
         val caseClassName = methodClassName.nestedClass(caseName)
         code.addStatement(
             "ct?.match(%L) == true -> %L",
             errorContentType.toContentTypeCodeBlock(),
-            buildResponseCaseExpression(caseClassName, errorModel),
+            buildResponseCaseExpression(caseClassName, errorBody),
         )
     }
     val preferredCaseName = "${contentTypeToIdentifier(preferredVariant.first)}${statusCode.toCaseName()}"
@@ -612,11 +648,15 @@ private fun Route.addMultiContentTypeSealedResponseDefaultCase(
 ) {
     if (returns.default != null) {
         val defaultClassName = methodClassName.nestedClass("Default")
-        val defaultModel = returns.default!!.types[contentType] ?: returns.default!!.preferredModel()
-        if (defaultModel != null && defaultModel !is Model.Primitive.Unit) {
-            code.addStatement("else -> %T(response.status, response.%M())", defaultClassName, BodyMember)
-        } else {
-            code.addStatement("else -> %T(response.status)", defaultClassName)
+        val defaultBody = returns.default!!.body(contentType) ?: returns.default!!.preferredBody()
+        when (defaultBody) {
+            is Route.ReturnBody.Raw -> code.addStatement("else -> %T(response.status, response)", defaultClassName)
+            is Route.ReturnBody.Typed -> if (defaultBody.model is Model.Primitive.Unit) {
+                code.addStatement("else -> %T(response.status)", defaultClassName)
+            } else {
+                code.addStatement("else -> %T(response.status, response.%M())", defaultClassName, BodyMember)
+            }
+            null -> code.addStatement("else -> %T(response.status)", defaultClassName)
         }
     } else {
         code.addStatement(
@@ -629,14 +669,18 @@ private fun Route.addMultiContentTypeSealedResponseDefaultCase(
 
 private fun buildResponseCaseExpression(
     caseClassName: ClassName,
-    model: Model?,
+    body: Route.ReturnBody?,
 ): CodeBlock =
-    when {
-        model == null || model is Model.Primitive.Unit -> CodeBlock.of("%T", caseClassName)
-        model.isRouteInlineModel() && model !is Model.Collection ->
-            CodeBlock.of("response.%M<%T>()", BodyMember, caseClassName)
+    when (body) {
+        is Route.ReturnBody.Raw -> CodeBlock.of("%T(response)", caseClassName)
+        is Route.ReturnBody.Typed -> when {
+            body.model is Model.Primitive.Unit -> CodeBlock.of("%T", caseClassName)
+            body.model.isRouteInlineModel() && body.model !is Model.Collection ->
+                CodeBlock.of("response.%M<%T>()", BodyMember, caseClassName)
 
-        else -> CodeBlock.of("%T(response.%M())", caseClassName, BodyMember)
+            else -> CodeBlock.of("%T(response.%M())", caseClassName, BodyMember)
+        }
+        null -> CodeBlock.of("%T", caseClassName)
     }
 
 private fun Route.hasRequestConfig(includeBody: Boolean): Boolean {

--- a/renderer/src/jvmMain/kotlin/io/github/nomisrev/openapi/TypeMapping.kt
+++ b/renderer/src/jvmMain/kotlin/io/github/nomisrev/openapi/TypeMapping.kt
@@ -19,6 +19,7 @@ private val InstantType = ClassName("kotlin.time", "Instant")
 private val JsonElementType = ClassName("kotlinx.serialization.json", "JsonElement")
 private val JsonArrayType = ClassName("kotlinx.serialization.json", "JsonArray")
 private val ListType = ClassName("kotlin.collections", "List")
+internal val HttpResponseType = ClassName("io.ktor.client.statement", "HttpResponse")
 
 @Suppress("CyclomaticComplexMethod")
 fun Model.toTypeName(config: RenderConfig): TypeName = when (this) {

--- a/renderer/src/jvmTest/kotlin/io/github/nomisrev/render/ClientSpec.kt
+++ b/renderer/src/jvmTest/kotlin/io/github/nomisrev/render/ClientSpec.kt
@@ -2330,6 +2330,68 @@ val clientSpec by testSuite {
         "client/inline-union-case-with-nested-enum"
     )
 
+    clientTest(
+        """
+        {
+          "openapi": "3.1.0",
+          "info": { "title": "Api", "version": "0.0.1" },
+          "paths": {
+            "/audio": {
+              "get": {
+                "responses": {
+                  "200": {
+                    "description": "Raw audio stream",
+                    "content": {
+                      "audio/wav": {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """.trimIndent(),
+        "client/raw-single-response"
+    )
+
+    clientTest(
+        """
+        {
+          "openapi": "3.1.0",
+          "info": { "title": "Api", "version": "0.0.1" },
+          "paths": {
+            "/reports": {
+              "get": {
+                "responses": {
+                  "200": {
+                    "description": "OK",
+                    "content": {
+                      "application/json": {
+                        "schema": { "type": "string" }
+                      }
+                    }
+                  },
+                  "400": {
+                    "description": "Bad request raw audio diagnostics",
+                    "content": {
+                      "audio/wav": {}
+                    }
+                  },
+                  "default": {
+                    "description": "Fallback image",
+                    "content": {
+                      "image/png": {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """.trimIndent(),
+        "client/raw-error-and-default-response"
+    )
+
     test("ambiguous form overload emits warning and is omitted when json body is available") {
         val json = """
         {

--- a/renderer/src/jvmTest/kotlin/io/github/nomisrev/render/ContentTypeStrategyTest.kt
+++ b/renderer/src/jvmTest/kotlin/io/github/nomisrev/render/ContentTypeStrategyTest.kt
@@ -11,6 +11,7 @@ import io.github.nomisrev.openapi.contentTypeToIdentifier
 import io.github.nomisrev.openapi.contentTypeToMethodName
 import io.github.nomisrev.openapi.contentTypeStrategy
 import io.github.nomisrev.openapi.detectSignatureClashes
+import io.github.nomisrev.openapi.preferredBody
 import io.github.nomisrev.openapi.toKotlinSignature
 import io.github.nomisrev.openapi.toTypeName
 import io.github.nomisrev.openapi.routes.Route
@@ -89,12 +90,27 @@ class ContentTypeStrategyTest {
     }
 
     @Test
+    fun `preferred body falls back to raw content when no typed response body exists`() {
+        assertEquals(
+            Route.ReturnBody.Raw,
+            rawReturnType(ContentType.parse("audio/wav")).preferredBody(),
+        )
+    }
+
+    @Test
     fun `error case classification covers no content single and multiple content types`() {
         assertEquals(
             io.github.nomisrev.openapi.ErrorCaseStrategy.NoContent,
             classifyErrorStatus(
                 HttpStatusCode.NoContent,
                 returnType(ContentType.Application.Json to stringModel()),
+            ),
+        )
+        assertEquals(
+            io.github.nomisrev.openapi.ErrorCaseStrategy.NoContent,
+            classifyErrorStatus(
+                HttpStatusCode.BadRequest,
+                Route.ReturnType(types = emptyMap(), extensions = emptyMap()),
             ),
         )
         assertEquals(
@@ -112,6 +128,16 @@ class ContentTypeStrategyTest {
             classifyErrorStatus(
                 HttpStatusCode.BadRequest,
                 returnType(ContentType.Application.Json to stringModel()),
+            ),
+        )
+        assertEquals(
+            io.github.nomisrev.openapi.ErrorCaseStrategy.SingleContentType(
+                contentType = ContentType.parse("audio/wav"),
+                body = Route.ReturnBody.Raw,
+            ),
+            classifyErrorStatus(
+                HttpStatusCode.BadRequest,
+                rawReturnType(ContentType.parse("audio/wav")),
             ),
         )
         assertEquals(
@@ -298,6 +324,13 @@ class ContentTypeStrategyTest {
     private fun returnType(vararg entries: Pair<ContentType, Model>): Route.ReturnType =
         Route.ReturnType(
             types = mapOf(*entries),
+            extensions = emptyMap(),
+        )
+
+    private fun rawReturnType(vararg contentTypes: ContentType): Route.ReturnType =
+        Route.ReturnType(
+            types = emptyMap(),
+            rawContentTypes = setOf(*contentTypes),
             extensions = emptyMap(),
         )
 

--- a/renderer/src/jvmTest/kotlin/io/github/nomisrev/render/ContentTypeStrategyTest.kt
+++ b/renderer/src/jvmTest/kotlin/io/github/nomisrev/render/ContentTypeStrategyTest.kt
@@ -107,7 +107,7 @@ class ContentTypeStrategyTest {
         assertEquals(
             io.github.nomisrev.openapi.ErrorCaseStrategy.SingleContentType(
                 contentType = ContentType.Application.Json,
-                model = stringModel(),
+                body = Route.ReturnBody.Typed(stringModel()),
             ),
             classifyErrorStatus(
                 HttpStatusCode.BadRequest,
@@ -117,8 +117,8 @@ class ContentTypeStrategyTest {
         assertEquals(
             io.github.nomisrev.openapi.ErrorCaseStrategy.MultipleContentTypes(
                 variants = listOf(
-                    ContentType.Application.Json to stringModel(),
-                    ContentType.parse("application/scim+json") to referenceModel("ScimError"),
+                    ContentType.Application.Json to Route.ReturnBody.Typed(stringModel()),
+                    ContentType.parse("application/scim+json") to Route.ReturnBody.Typed(referenceModel("ScimError")),
                 ),
             ),
             classifyErrorStatus(

--- a/renderer/src/jvmTest/resources/kotlinTestData/client/raw-error-and-default-response/Api.kt
+++ b/renderer/src/jvmTest/resources/kotlinTestData/client/raw-error-and-default-response/Api.kt
@@ -1,0 +1,32 @@
+package io.github.nomisrev.render.test.client.raw.error.and.default.response
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.serialization.kotlinx.json.json
+import kotlin.AutoCloseable
+import kotlin.String
+import kotlin.Unit
+
+public class Api internal constructor(
+  private val client: HttpClient,
+) : AutoCloseable {
+  public val reports: Reports = Reports(client)
+
+  public constructor(baseUrl: String, block: HttpClientConfig<*>.() -> Unit) : this(HttpClient {
+    defaultRequest { url(baseUrl) }
+    block()
+  }
+  )
+
+  public constructor(baseUrl: String) : this(HttpClient {
+    defaultRequest { url(baseUrl) }
+    install(ContentNegotiation) { json() }
+  }
+  )
+
+  override fun close() {
+    client.close()
+  }
+}

--- a/renderer/src/jvmTest/resources/kotlinTestData/client/raw-error-and-default-response/Reports.kt
+++ b/renderer/src/jvmTest/resources/kotlinTestData/client/raw-error-and-default-response/Reports.kt
@@ -1,0 +1,42 @@
+package io.github.nomisrev.render.test.client.raw.error.and.default.response
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.`get`
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import kotlin.String
+
+public class Reports internal constructor(
+  private val client: HttpClient,
+) {
+  public val `get`: Get = Get(client)
+
+  public class Get internal constructor(
+    private val client: HttpClient,
+  ) {
+    public suspend operator fun invoke(): Response {
+      val response = client.get("/reports")
+      return when (response.status.value) {
+        200 -> Response.Ok(response.body())
+        400 -> Response.BadRequest(response)
+        else -> Response.Default(response.status, response)
+      }
+    }
+
+    public sealed interface Response {
+      public data class Ok(
+        public val `value`: String,
+      ) : Response
+
+      public data class BadRequest(
+        public val `value`: HttpResponse,
+      ) : Response
+
+      public data class Default(
+        public val status: HttpStatusCode,
+        public val `value`: HttpResponse,
+      ) : Response
+    }
+  }
+}

--- a/renderer/src/jvmTest/resources/kotlinTestData/client/raw-single-response/Api.kt
+++ b/renderer/src/jvmTest/resources/kotlinTestData/client/raw-single-response/Api.kt
@@ -1,0 +1,32 @@
+package io.github.nomisrev.render.test.client.raw.single.response
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.serialization.kotlinx.json.json
+import kotlin.AutoCloseable
+import kotlin.String
+import kotlin.Unit
+
+public class Api internal constructor(
+  private val client: HttpClient,
+) : AutoCloseable {
+  public val audio: Audio = Audio(client)
+
+  public constructor(baseUrl: String, block: HttpClientConfig<*>.() -> Unit) : this(HttpClient {
+    defaultRequest { url(baseUrl) }
+    block()
+  }
+  )
+
+  public constructor(baseUrl: String) : this(HttpClient {
+    defaultRequest { url(baseUrl) }
+    install(ContentNegotiation) { json() }
+  }
+  )
+
+  override fun close() {
+    client.close()
+  }
+}

--- a/renderer/src/jvmTest/resources/kotlinTestData/client/raw-single-response/Audio.kt
+++ b/renderer/src/jvmTest/resources/kotlinTestData/client/raw-single-response/Audio.kt
@@ -1,0 +1,20 @@
+package io.github.nomisrev.render.test.client.raw.single.response
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.`get`
+import io.ktor.client.statement.HttpResponse
+
+public class Audio internal constructor(
+  private val client: HttpClient,
+) {
+  public val `get`: Get = Get(client)
+
+  public class Get internal constructor(
+    private val client: HttpClient,
+  ) {
+    public suspend operator fun invoke(): HttpResponse {
+      val response = client.get("/audio")
+      return response
+    }
+  }
+}

--- a/typed/src/commonMain/kotlin/io/github/nomisrev/openapi/routes/Return.kt
+++ b/typed/src/commonMain/kotlin/io/github/nomisrev/openapi/routes/Return.kt
@@ -1,5 +1,6 @@
 package io.github.nomisrev.openapi.routes
 
+import io.github.nomisrev.openapi.Model
 import io.github.nomisrev.openapi.NamingContext
 import io.github.nomisrev.openapi.PathSegment
 import io.github.nomisrev.openapi.parser.Operation
@@ -19,30 +20,61 @@ suspend fun resolveReturns(
     operation: Operation,
 ): Route.Returns =
     Route.Returns(
-        default = operation.responses.default?.resolve()?.toReturnType(path, segments, method),
+        default = operation.responses.default?.resolve()?.toReturnType(segments, method),
         responses = operation.responses.responses.entries.associate { [code, response] ->
-            Pair(HttpStatusCode.fromValue(code), response.resolve().toReturnType(path, segments, method))
+            Pair(HttpStatusCode.fromValue(code), response.resolve().toReturnType(segments, method))
         },
         extensions = operation.responses.extensions
     )
 
 context(ctx: Registry)
 private suspend fun Response.toReturnType(
-    path: String,
     segments: List<PathSegment>,
     method: HttpMethod,
-): Route.ReturnType = Route.ReturnType(
-    types = content.entries.associate { [contentType, mediaType] ->
-        val schema = requireNotNull(mediaType.schema) {
-            "Response without $mediaType schema for ${method.value} $path. $this"
-        }
-        Pair(
-            ContentType.parse(contentType),
-            schema.toModel(NamingContext.path(segments, method).nest(NamingContext.Response), SchemaContext.Read)
-        )
-    },
-    extensions = extensions
-)
+): Route.ReturnType {
+    val typed = linkedMapOf<ContentType, Model>()
+    val raw = linkedSetOf<ContentType>()
+    content.entries.forEach { [contentType, mediaType] ->
+        val parsedContentType = ContentType.parse(contentType)
+        val model = mediaType.schema?.toModel(
+            NamingContext.path(segments, method).nest(NamingContext.Response),
+            SchemaContext.Read
+        ) ?: parsedContentType.inferredModelWithoutSchema()
+
+        if (model == null) raw += parsedContentType
+        else typed[parsedContentType] = model
+    }
+    return Route.ReturnType(
+        types = typed,
+        rawContentTypes = raw,
+        extensions = extensions,
+    )
+}
+
+private fun ContentType.inferredModelWithoutSchema(): Model? {
+    val [type, subtype] = typeAndSubtype()
+    return when {
+        subtype == "json" || subtype.endsWith("+json") ->
+            Model.FreeFormJson(description = null, constraint = null, isNullable = false, title = null)
+
+        type == "text" || subtype.isTextualApplicationSubtype() ->
+            Model.Primitive.String(default = null, description = null, constraint = null, isNullable = false, title = null)
+
+        else -> null
+    }
+}
+
+private fun ContentType.typeAndSubtype(): List<String> {
+    val normalized = toString().substringBefore(';').trim().lowercase()
+    val parts = normalized.split('/', limit = 2)
+    return if (parts.size == 2) parts else listOf(parts.firstOrNull().orEmpty(), "")
+}
+
+private fun String.isTextualApplicationSubtype(): Boolean =
+    this == "xml" || endsWith("+xml") ||
+            this == "yaml" || this == "x-yaml" || endsWith("+yaml") || endsWith("+x-yaml") ||
+            this == "javascript" || this == "x-javascript" ||
+            this == "graphql" || this == "x-www-form-urlencoded"
 
 // TODO Move to Registry and support top-level schemas.
 context(ctx: Registry)

--- a/typed/src/commonMain/kotlin/io/github/nomisrev/openapi/routes/Route.kt
+++ b/typed/src/commonMain/kotlin/io/github/nomisrev/openapi/routes/Route.kt
@@ -211,8 +211,30 @@ data class Route(
         val extensions: Map<String, JsonElement>,
     )
 
+    sealed interface ReturnBody {
+        data class Typed(val model: Model) : ReturnBody
+        data object Raw : ReturnBody
+    }
+
     // Required
-    data class ReturnType(val types: Map<ContentType, Model>, val extensions: Map<String, JsonElement>)
+    data class ReturnType(
+        val types: Map<ContentType, Model>,
+        val rawContentTypes: Set<ContentType> = emptySet(),
+        val extensions: Map<String, JsonElement>,
+    ) {
+        fun body(contentType: ContentType): ReturnBody? =
+            types[contentType]?.let(ReturnBody::Typed)
+                ?: types.entries
+                    .firstOrNull { [candidate, _] -> candidate.match(contentType) || contentType.match(candidate) }
+                    ?.let { [_, model] -> ReturnBody.Typed(model) }
+                ?: rawContentTypes
+                    .firstOrNull { candidate -> candidate.match(contentType) || contentType.match(candidate) }
+                    ?.let { ReturnBody.Raw }
+
+        fun bodies(): List<Pair<ContentType, ReturnBody>> =
+            types.entries.map { [contentType, model] -> contentType to ReturnBody.Typed(model) } +
+                    rawContentTypes.map { contentType -> contentType to ReturnBody.Raw }
+    }
 }
 
 private fun Bodies?.nested(): Set<Model> =

--- a/typed/src/commonTest/kotlin/io/github/nomisrev/Values.kt
+++ b/typed/src/commonTest/kotlin/io/github/nomisrev/Values.kt
@@ -128,6 +128,8 @@ fun Constraints.Number.Companion.all(): List<Expect<SchemaNumberConstraints, Con
                 Constraints.Number(bound(-1000.0, exclusive = true), null, null),
         SchemaNumberConstraints(Schema.ExclusiveLimit.NumberValue(-1000.0), 0.0, null, null, null) expect
                 Constraints.Number(bound(0.0, exclusive = false), null, null),
+        SchemaNumberConstraints(Schema.ExclusiveLimit.NumberValue(-1000.0), -1000.0, null, null, null) expect
+                Constraints.Number(bound(-1000.0, exclusive = true), null, null),
         SchemaNumberConstraints(Schema.ExclusiveLimit.NumberValue(0.0), -1000.0, null, null, null) expect
                 Constraints.Number(bound(0.0, exclusive = true), null, null),
         SchemaNumberConstraints(null, null, null, 1000.0, null) expect
@@ -140,6 +142,8 @@ fun Constraints.Number.Companion.all(): List<Expect<SchemaNumberConstraints, Con
                 Constraints.Number(null, bound(1000.0, exclusive = true), null),
         SchemaNumberConstraints(null, null, Schema.ExclusiveLimit.NumberValue(1000.0), 0.0, null) expect
                 Constraints.Number(null, bound(0.0, exclusive = false), null),
+        SchemaNumberConstraints(null, null, Schema.ExclusiveLimit.NumberValue(1000.0), 1000.0, null) expect
+                Constraints.Number(null, bound(1000.0, exclusive = true), null),
         SchemaNumberConstraints(null, null, Schema.ExclusiveLimit.NumberValue(0.0), 1000.0, null) expect
                 Constraints.Number(null, bound(0.0, exclusive = true), null),
         SchemaNumberConstraints(

--- a/typed/src/commonTest/kotlin/io/github/nomisrev/Values.kt
+++ b/typed/src/commonTest/kotlin/io/github/nomisrev/Values.kt
@@ -128,8 +128,6 @@ fun Constraints.Number.Companion.all(): List<Expect<SchemaNumberConstraints, Con
                 Constraints.Number(bound(-1000.0, exclusive = true), null, null),
         SchemaNumberConstraints(Schema.ExclusiveLimit.NumberValue(-1000.0), 0.0, null, null, null) expect
                 Constraints.Number(bound(0.0, exclusive = false), null, null),
-        SchemaNumberConstraints(Schema.ExclusiveLimit.NumberValue(-1000.0), -1000.0, null, null, null) expect
-                Constraints.Number(bound(-1000.0, exclusive = true), null, null),
         SchemaNumberConstraints(Schema.ExclusiveLimit.NumberValue(0.0), -1000.0, null, null, null) expect
                 Constraints.Number(bound(0.0, exclusive = true), null, null),
         SchemaNumberConstraints(null, null, null, 1000.0, null) expect
@@ -142,8 +140,6 @@ fun Constraints.Number.Companion.all(): List<Expect<SchemaNumberConstraints, Con
                 Constraints.Number(null, bound(1000.0, exclusive = true), null),
         SchemaNumberConstraints(null, null, Schema.ExclusiveLimit.NumberValue(1000.0), 0.0, null) expect
                 Constraints.Number(null, bound(0.0, exclusive = false), null),
-        SchemaNumberConstraints(null, null, Schema.ExclusiveLimit.NumberValue(1000.0), 1000.0, null) expect
-                Constraints.Number(null, bound(1000.0, exclusive = true), null),
         SchemaNumberConstraints(null, null, Schema.ExclusiveLimit.NumberValue(0.0), 1000.0, null) expect
                 Constraints.Number(null, bound(0.0, exclusive = true), null),
         SchemaNumberConstraints(

--- a/typed/src/commonTest/kotlin/io/github/nomisrev/openapi/routes/ReturnSpec.kt
+++ b/typed/src/commonTest/kotlin/io/github/nomisrev/openapi/routes/ReturnSpec.kt
@@ -15,10 +15,41 @@ import io.github.nomisrev.openapi.registry.Registry
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 val ReturnSpec by testSuite {
+    test("ReturnType resolves typed and raw bodies by exact and matching content type") {
+        val json = ContentType.Application.Json
+        val jsonWithCharset = ContentType.parse("application/json; charset=utf-8")
+        val audio = ContentType.parse("audio/wav")
+        val audioAny = ContentType.parse("audio/*")
+        val model = Model.Primitive.String(
+            default = null,
+            description = null,
+            constraint = null,
+            isNullable = false,
+            title = null,
+        )
+        val returnType = Route.ReturnType(
+            types = mapOf(jsonWithCharset to model),
+            rawContentTypes = setOf(audioAny),
+            extensions = emptyMap(),
+        )
+
+        assertEquals(Route.ReturnBody.Typed(model), returnType.body(jsonWithCharset))
+        assertEquals(Route.ReturnBody.Typed(model), returnType.body(json))
+        assertEquals(Route.ReturnBody.Raw, returnType.body(audio))
+        assertEquals(
+            listOf(
+                jsonWithCharset to Route.ReturnBody.Typed(model),
+                audioAny to Route.ReturnBody.Raw,
+            ),
+            returnType.bodies(),
+        )
+    }
+
     test("resolveReturns handles null schema with raw response for audio/wav") {
         val openAPI = OpenAPI(
             info = Info(title = "Test", version = "1.0.0"),
@@ -146,7 +177,11 @@ val ReturnSpec by testSuite {
                                         description = "OK",
                                         content = mapOf(
                                             "application/problem+json" to MediaType(schema = null),
+                                            "text/plain" to MediaType(schema = null),
                                             "application/xml" to MediaType(schema = null),
+                                            "application/x-yaml" to MediaType(schema = null),
+                                            "application/graphql" to MediaType(schema = null),
+                                            "application/x-www-form-urlencoded" to MediaType(schema = null),
                                             "application/octet-stream" to MediaType(schema = null),
                                             "application/vnd.example" to MediaType(schema = null),
                                         )
@@ -169,7 +204,11 @@ val ReturnSpec by testSuite {
                 )
                 val returnType = returns.responses[HttpStatusCode.OK]!!
                 assertIs<Model.FreeFormJson>(returnType.types[ContentType.parse("application/problem+json")])
+                assertIs<Model.Primitive.String>(returnType.types[ContentType.Text.Plain])
                 assertIs<Model.Primitive.String>(returnType.types[ContentType.parse("application/xml")])
+                assertIs<Model.Primitive.String>(returnType.types[ContentType.parse("application/x-yaml")])
+                assertIs<Model.Primitive.String>(returnType.types[ContentType.parse("application/graphql")])
+                assertIs<Model.Primitive.String>(returnType.types[ContentType.Application.FormUrlEncoded])
                 assertTrue(ContentType.Application.OctetStream in returnType.rawContentTypes)
                 assertTrue(ContentType.parse("application/vnd.example") in returnType.rawContentTypes)
             }

--- a/typed/src/commonTest/kotlin/io/github/nomisrev/openapi/routes/ReturnSpec.kt
+++ b/typed/src/commonTest/kotlin/io/github/nomisrev/openapi/routes/ReturnSpec.kt
@@ -1,7 +1,5 @@
 package io.github.nomisrev.openapi.routes
 
-import de.infix.testBalloon.framework.core.TestConfig
-import de.infix.testBalloon.framework.core.disable
 import de.infix.testBalloon.framework.core.testSuite
 import io.github.nomisrev.openapi.Model
 import io.github.nomisrev.openapi.parser.Info
@@ -11,15 +9,17 @@ import io.github.nomisrev.openapi.parser.PathItem
 import io.github.nomisrev.openapi.parser.Responses
 import io.github.nomisrev.openapi.parser.Response
 import io.github.nomisrev.openapi.parser.MediaType
+import io.github.nomisrev.openapi.parser.Schema
 import io.github.nomisrev.openapi.parser.ReferenceOr
 import io.github.nomisrev.openapi.registry.Registry
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
-val ReturnSpec by testSuite(testConfig = TestConfig.disable()) {
-    test("resolveReturns handles null schema with ByteArray for audio/wav") {
+val ReturnSpec by testSuite {
+    test("resolveReturns handles null schema with raw response for audio/wav") {
         val openAPI = OpenAPI(
             info = Info(title = "Test", version = "1.0.0"),
             paths = mapOf(
@@ -51,8 +51,46 @@ val ReturnSpec by testSuite(testConfig = TestConfig.disable()) {
                     operation = openAPI.paths["/test"]!!.get!!
                 )
                 val returnType = returns.responses[HttpStatusCode.OK]!!
-                val model = returnType.types[ContentType.parse("audio/wav")]!!
-                assertIs<Model.ByteArray>(model)
+                assertTrue(ContentType.parse("audio/wav") in returnType.rawContentTypes)
+            }
+        }
+    }
+
+    test("resolveReturns keeps explicit binary schema as ByteArray") {
+        val openAPI = OpenAPI(
+            info = Info(title = "Test", version = "1.0.0"),
+            paths = mapOf(
+                "/test" to PathItem(
+                    get = Operation(
+                        responses = Responses(
+                            responses = mapOf(
+                                200 to ReferenceOr.Value(
+                                    Response(
+                                        description = "OK",
+                                        content = mapOf(
+                                            "application/octet-stream" to MediaType(
+                                                schema = ReferenceOr.Value(Schema.string.copy(format = "binary"))
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        Registry(openAPI).use { registry ->
+            with(registry) {
+                val returns = resolveReturns(
+                    path = "/test",
+                    segments = emptyList(),
+                    method = HttpMethod.Get,
+                    operation = openAPI.paths["/test"]!!.get!!
+                )
+                val returnType = returns.responses[HttpStatusCode.OK]!!
+                assertIs<Model.ByteArray>(returnType.types[ContentType.Application.OctetStream])
             }
         }
     }
@@ -91,6 +129,49 @@ val ReturnSpec by testSuite(testConfig = TestConfig.disable()) {
                 val returnType = returns.responses[HttpStatusCode.OK]!!
                 val model = returnType.types[ContentType.Application.Json]!!
                 assertIs<Model.FreeFormJson>(model)
+            }
+        }
+    }
+
+    test("resolveReturns infers usable models for null schemas by content type") {
+        val openAPI = OpenAPI(
+            info = Info(title = "Test", version = "1.0.0"),
+            paths = mapOf(
+                "/test" to PathItem(
+                    get = Operation(
+                        responses = Responses(
+                            responses = mapOf(
+                                200 to ReferenceOr.Value(
+                                    Response(
+                                        description = "OK",
+                                        content = mapOf(
+                                            "application/problem+json" to MediaType(schema = null),
+                                            "application/xml" to MediaType(schema = null),
+                                            "application/octet-stream" to MediaType(schema = null),
+                                            "application/vnd.example" to MediaType(schema = null),
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        Registry(openAPI).use { registry ->
+            with(registry) {
+                val returns = resolveReturns(
+                    path = "/test",
+                    segments = emptyList(),
+                    method = HttpMethod.Get,
+                    operation = openAPI.paths["/test"]!!.get!!
+                )
+                val returnType = returns.responses[HttpStatusCode.OK]!!
+                assertIs<Model.FreeFormJson>(returnType.types[ContentType.parse("application/problem+json")])
+                assertIs<Model.Primitive.String>(returnType.types[ContentType.parse("application/xml")])
+                assertTrue(ContentType.Application.OctetStream in returnType.rawContentTypes)
+                assertTrue(ContentType.parse("application/vnd.example") in returnType.rawContentTypes)
             }
         }
     }


### PR DESCRIPTION
This PR adds some way to attempt to detect a meaningful return type.

For schemaless xml it will return `String`, `YamlMap` for raw yaml, `JsonElement` for raw json, or Ktor's HttpResponse when it cannot be deferred such that the user has full control over the response.